### PR TITLE
Add min/max tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ console.log('Count: '+numbers.count());
 console.log('Mean: '+numbers.mean());
 console.log('Variance: '+numbers.variance());
 console.log('Standard Deviation: '+numbers.standardDeviation());
+console.log('Min: '+numbers.min());
+console.log('Max: '+numbers.max());
 
 numbers.clear();
 ```

--- a/lib/standard-deviation-stream.js
+++ b/lib/standard-deviation-stream.js
@@ -2,9 +2,10 @@ module.exports = function (key, redisClient) {
   this.saveKey = key;
   this.newMean = 0;
   this.newVariance = 0;
-
   this.oldMean = 0;
   this.oldVariance = 0;
+  this.currentMin = 0;
+  this.currentMax = 0;
 
   this.valueCount = 0;
 
@@ -13,7 +14,10 @@ module.exports = function (key, redisClient) {
     this.valueCount++;
     if (this.valueCount == 1)
     {
-      this.oldMean = this.newMean = incomingNumber;
+      this.oldMean =
+      this.newMean =
+      this.currentMin =
+      this.currentMax = incomingNumber;
       this.oldVariance = 0;
     }
     else
@@ -22,6 +26,8 @@ module.exports = function (key, redisClient) {
       this.newVariance = this.oldVariance + (incomingNumber - this.oldMean) * (incomingNumber - this.newMean);
       this.oldMean = this.newMean;
       this.oldVariance = this.newVariance;
+      this.currentMin = Math.min(this.currentMin, incomingNumber);
+      this.currentMax = Math.max(this.currentMax, incomingNumber);
     }
   };
 
@@ -32,6 +38,8 @@ module.exports = function (key, redisClient) {
     this.oldMean = 0;
     this.newVariance = 0;
     this.oldVariance = 0;
+    this.currentMin = 0;
+    this.currentMax = 0;
     if (redisClient)
       redisClient.del(this.saveKey, done);
     else
@@ -58,6 +66,16 @@ module.exports = function (key, redisClient) {
     return Math.sqrt(this.variance());
   };
 
+  // Get the minimum value
+  this.min = function () {
+    return this.currentMin;
+  };
+
+  // Get the maximum value
+  this.max = function () {
+    return this.currentMax;
+  };
+
   //Restore the state of the deviation stream from cache
   this.restore = function (done) {
     if (redisClient) {
@@ -77,6 +95,10 @@ module.exports = function (key, redisClient) {
               self.newVariance = result.newVariance;
               self.oldMean = result.oldMean;
               self.oldVariance = result.oldVariance;
+              self.currentMin = result.currentMin === undefined ? // so we can restore with backwards compatability
+                Number.MAX_SAFE_INTEGER : result.currentMin;
+              self.currentMax = result.currentMax === undefined ? // so we can restore with backwards compatability
+                Number.MIN_SAFE_INTEGER : result.currentMax;
             }
             done();
           }
@@ -99,7 +121,9 @@ module.exports = function (key, redisClient) {
         newVariance: self.newVariance,
         oldMean: self.oldMean,
         oldVariance: self.oldVariance,
-        count: self.valueCount
+        count: self.valueCount,
+        currentMin: self.currentMin,
+        currentMax: self.currentMax,
       };
 
       redisClient.multi()

--- a/tests/test.js
+++ b/tests/test.js
@@ -70,6 +70,8 @@ describe('Standard Deviation Stream', function () {
       expect(testDeviation.count()).to.equal(30);
       expect(testDeviation.mean()).to.equal(50);
       expect(testDeviation.standardDeviation()).to.be.above(49).below(51);
+      expect(testDeviation.min()).to.equal(0);
+      expect(testDeviation.max()).to.equal(100);
     });
   });
 
@@ -96,6 +98,8 @@ describe('Standard Deviation Stream', function () {
       expect(restoredDeviation.count()).to.equal(30);
       expect(restoredDeviation.mean()).to.equal(50);
       expect(restoredDeviation.standardDeviation()).to.be.above(49).below(51);
+      expect(testDeviation.min()).to.equal(0);
+      expect(testDeviation.max()).to.equal(100);
     });
   });
 
@@ -123,6 +127,8 @@ describe('Standard Deviation Stream', function () {
       expect(testDeviation.mean()).to.equal(0);
       expect(testDeviation.variance()).to.equal(0);
       expect(testDeviation.standardDeviation()).to.equal(0);
+      expect(testDeviation.min()).to.equal(0);
+      expect(testDeviation.max()).to.equal(0);
     });
   });
 
@@ -163,6 +169,8 @@ describe('Standard Deviation Stream', function () {
       expect(testDeviation.count()).to.equal(50);
       expect(testDeviation.mean()).to.equal(50);
       expect(testDeviation.standardDeviation()).to.be.above(35).below(36);
+      expect(testDeviation.min()).to.equal(0);
+      expect(testDeviation.max()).to.equal(100);
     });
   });
 });


### PR DESCRIPTION
This might be out of scope for this project, but it was so easy to add I figured I might as well open a PR.

It's all pretty straightforward. The one exception is how I restore values from redis. If the saved state doesn't have a `currentMin` and `currentMax` value saved. I make the values `Number.MAX_SAFE_INTEGER` and `Number.MIN_SAFE_INTEGER` respectively. This makes sure the correct values are calculated on the next `.push(n)`. This is entirely for backwards compatibility reasons.
